### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "ruby"
+run = "main.rb"

--- a/README.md
+++ b/README.md
@@ -7,3 +7,5 @@ To add class just copy one in `lib/heroes` and change stats to desired, don't fo
 
 To add custom abilities or\and change existing, use methods `buffs` and `spells` in `lib/abilities.rb` as examples. Just add 
 new spell to hash in likeness of existing and enjoy. 
+
+[![Run on Repl.it](https://repl.it/badge/github/tee0zed/KnightsOfVeanor)](https://repl.it/github/tee0zed/KnightsOfVeanor)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@RMenkl/KnightsOfVeanor).